### PR TITLE
Fixed $filePath.

### DIFF
--- a/core/connector/s3/php5/CommandHandler/DeleteFiles.php
+++ b/core/connector/s3/php5/CommandHandler/DeleteFiles.php
@@ -117,7 +117,7 @@ class CKFinder_Connector_CommandHandler_DeleteFiles extends CKFinder_Connector_C
           $this->_errorHandler->throwError(CKFINDER_CONNECTOR_ERROR_UNAUTHORIZED);
         }
 
-        $filePath = substr($_resourceTypeConfig[$type]->getDirectory().$path.$name, 1);
+        $filePath = substr($_resourceTypeConfig[$type]->getDirectory().$path.'/'.$name, 1);
 
 //        if (!file_exists($filePath) || !is_file($filePath) ) {
 //          $errorCode = CKFINDER_CONNECTOR_ERROR_FILE_NOT_FOUND;


### PR DESCRIPTION
Fixed $filePath. The original path doesn't have the slash between the URL and the file name.